### PR TITLE
Fixed data URL inside /api/src/config.js, also added a env variable with name CLUSTER_NAME to use in data URL

### DIFF
--- a/microservices/api/k8s.yaml
+++ b/microservices/api/k8s.yaml
@@ -25,6 +25,9 @@ items:
           ports:
           - containerPort: 8080
             protocol: TCP
+          env:
+          - name: CLUSTER_NAME
+            value: {{ cluster.name }}
           resources: {}
         securityContext: {}
         terminationGracePeriodSeconds: 0

--- a/microservices/api/src/config.js
+++ b/microservices/api/src/config.js
@@ -1,6 +1,6 @@
 let projectConfig = {
     url: {
-        data: 'http://data.hasura/v1/query',
+        data: 'http://data.' + process.env.CLUSTER_NAME + '.hasura-app.io/v1/query'
     }
 }
 


### PR DESCRIPTION
Inside config.js, this was present: 
`url: {
        data: 'http://data.hasura/v1/query',
    }`
Fixed it to: `url: {
        data: 'http://data.' + process.env.CLUSTER_NAME + '.hasura-app.io/v1/query'
    }`

For accessing CLUSTER_NAME I added an env variable in k8s.yaml.