### PR TITLE
fix invalid flag for serve

### DIFF
--- a/microservices/ui/Dockerfile
+++ b/microservices/ui/Dockerfile
@@ -25,7 +25,7 @@ RUN cd /app && npm run build
 WORKDIR /app
 
 # Step 9: Serve the app at port 8080 using the serve package
-CMD ["serve", "-s", "build", "-p", "8080"]
+CMD ["serve", "-s", "build", "-l", "8080"]
 
 # Step 9: Hot reloading
 # Comment line 28 and un-comment the next line to enable hot reloading:


### PR DESCRIPTION
Fixed  error when serve attempts to create HTTP server due to invalid flag.

Error log: ERROR: Unknown or unexpected option: -p